### PR TITLE
ci: enforce min-release-age gate + suppress lagging undici scanner finding

### DIFF
--- a/.github/scripts/check-lockfile-quarantine.mjs
+++ b/.github/scripts/check-lockfile-quarantine.mjs
@@ -1,0 +1,85 @@
+// Blocking quarantine gate: fails if any package version ADDED or CHANGED in the
+// PR's lockfiles (vs the base branch) is younger than QUARANTINE_DAYS.
+//
+// This enforces the .npmrc `min-release-age` policy at merge time. `npm ci`
+// installs the exact versions already pinned in the lockfile WITHOUT re-checking
+// their age, so a too-new version committed by Dependabot (or a human) can
+// otherwise sail through the required test jobs and only blow up later in steps
+// that re-resolve (e.g. `npm audit signatures`). This gate closes that hole.
+//
+// Usage:  node check-lockfile-quarantine.mjs <base-ref>     (e.g. origin/dev)
+// Env:    QUARANTINE_DAYS (default 7)
+// Exit:   0 = clean, 1 = violation(s) found
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const base = process.argv[2] || 'origin/dev';
+const QUARANTINE_DAYS = parseInt(process.env.QUARANTINE_DAYS || '7', 10);
+const cutoff = Date.now() - QUARANTINE_DAYS * 86_400_000;
+
+function lockVersions(json) {
+  const map = new Map(); // "name@version" -> { name, version }
+  let obj;
+  try { obj = JSON.parse(json); } catch { return map; }
+  for (const [path, entry] of Object.entries(obj.packages || {})) {
+    const i = path.lastIndexOf('node_modules/');
+    if (i === -1 || !entry.version) continue;
+    const name = path.slice(i + 'node_modules/'.length);
+    map.set(`${name}@${entry.version}`, { name, version: entry.version });
+  }
+  return map;
+}
+
+function publishTime(name, version) {
+  try {
+    const out = execFileSync('npm', ['view', `${name}@${version}`, 'time', '--json'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        // read the real publish date regardless of the repo's own quarantine,
+        // and keep npm from printing config warnings into our output
+        npm_config_min_release_age: '',
+        npm_config_loglevel: 'error',
+      },
+    });
+    return JSON.parse(out)[version] || null;
+  } catch {
+    return null;
+  }
+}
+
+const violations = [];
+for (const ws of ['backend', 'frontend']) {
+  const lockPath = `${ws}/package-lock.json`;
+  let baseJson = '{}';
+  try { baseJson = execFileSync('git', ['show', `${base}:${lockPath}`], { encoding: 'utf8' }); } catch {}
+  let headJson;
+  try { headJson = readFileSync(lockPath, 'utf8'); } catch { continue; }
+
+  const baseVersions = lockVersions(baseJson);
+  const headVersions = lockVersions(headJson);
+  const checked = new Set();
+
+  for (const [key, info] of headVersions) {
+    if (baseVersions.has(key) || checked.has(key)) continue; // unchanged or already seen
+    checked.add(key);
+    const published = publishTime(info.name, info.version);
+    if (!published) {
+      violations.push(`${ws}: ${info.name}@${info.version} — publish date unknown (treated as blocked)`);
+      continue;
+    }
+    if (new Date(published).getTime() > cutoff) {
+      const ageDays = Math.floor((Date.now() - new Date(published).getTime()) / 86_400_000);
+      violations.push(`${ws}: ${info.name}@${info.version} — ${ageDays}d old (needs ${QUARANTINE_DAYS}d), published ${published}`);
+    }
+  }
+}
+
+if (violations.length) {
+  console.error(`min-release-age quarantine violation — newly introduced packages younger than ${QUARANTINE_DAYS} days:\n`);
+  for (const v of violations) console.error(`  - ${v}`);
+  console.error(`\nWait for these versions to age past ${QUARANTINE_DAYS} days, or pin an older release.`);
+  process.exit(1);
+}
+console.log(`All added/changed packages satisfy the ${QUARANTINE_DAYS}-day min-release-age policy.`);

--- a/.github/workflows/quarantine-gate.yml
+++ b/.github/workflows/quarantine-gate.yml
@@ -1,0 +1,39 @@
+name: Quarantine gate
+
+# Blocking enforcement of the .npmrc `min-release-age` policy. The required test
+# jobs run `npm ci`, which installs the versions already pinned in the lockfile
+# WITHOUT re-checking their age — so a too-new version (e.g. a Dependabot bump
+# whose target only just published) can pass tests and merge, then break later
+# steps that re-resolve. This gate fails the PR instead, for any package
+# added/changed in the lockfiles that is younger than the policy window.
+#
+# Make this a required status check on `main` and `dev` so it blocks merges.
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+permissions:
+  contents: read
+
+jobs:
+  quarantine:
+    name: Quarantine check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Enforce min-release-age on changed dependencies
+        env:
+          QUARANTINE_DAYS: 7
+          BASE: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE"
+          node .github/scripts/check-lockfile-quarantine.mjs "origin/$BASE"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,11 @@
 # Trivy vulnerability suppressions
 # Each entry must include a justification.
+
+# CVE-2026-12151 — undici WebSocket DoS, in npm's *bundled* undici
+# (/usr/local/lib/node_modules/npm/node_modules/undici).
+# npm@11.17.0 (latest) bundles undici 6.26.0, which the upstream GitHub advisory
+# lists as a patched version; Trivy's DB lags and only accepts >= 6.27.0. undici
+# is used solely by npm at build time — the runtime entrypoint is `node`, so it
+# is not reachable in the running container.
+# Remove once npm bundles undici >= 6.27.0.
+CVE-2026-12151


### PR DESCRIPTION
## Why

Two supply-chain follow-ups from the dependency sweep:

### 1. Suppress undici CVE-2026-12151 (Trivy DB lag)
The Docker image scan flags `undici` in npm's **bundled** deps
(`/usr/local/lib/node_modules/npm/node_modules/undici`). npm@11.17.0 (latest)
bundles undici **6.26.0**, which the upstream GitHub advisory lists as a
**patched** version — but Trivy's DB lags and only accepts ≥6.27.0, and no npm
release bundles that yet. undici there is a **build-time tool only** (runtime is
`node`), so it isn't reachable in the running container. Suppressed in
`.trivyignore` with justification, to be removed once npm bundles undici ≥6.27.0.
This mirrors the repo's established pattern (e.g. `05a249c`, `91bbfe6`).

### 2. Blocking min-release-age gate
The `.npmrc` `min-release-age=7` policy was only *labelled*, never enforced:
`npm ci` installs lockfile-pinned versions without re-checking age, so a too-new
bump (like react-router-dom 7.18.0) could pass the required tests and merge, then
fail later re-resolving steps. The new **Quarantine check** job diffs each PR's
lockfiles against the base and **fails** on any added/changed package younger
than 7 days. Make it a required check on `main`/`dev` to block such merges.

## Notes
- Dockerfile unchanged (npm-strip alternative considered but rejected as
  over-engineered for a scanner-lag finding on a build-time, already-patched lib).