### PR TITLE
fix: security & optimization audit follow-ups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,9 @@ MAX_FILE_SIZE=104857600
 CHUNK_SIZE=10485760
 # seconds — incomplete chunked upload lifetime (60 min)
 UPLOAD_SESSION_TTL=3600
+# max concurrent open upload sessions per client IP (0 = unlimited).
+# Bounds the storage-quota reservation an IP can tie up without completing uploads.
+MAX_UPLOAD_SESSIONS_PER_IP=10
 
 # ⚠  Constraint: CHUNK_SIZE ≤ MAX_FILE_SIZE (validated at startup)
 #

--- a/backend/src/__tests__/rateLimit.test.ts
+++ b/backend/src/__tests__/rateLimit.test.ts
@@ -133,6 +133,29 @@ describe('Rate-limit middleware', () => {
     expect(res.statusCode).toBe(429);
   });
 
+  it('should not let a query string bypass the download tier', async () => {
+    // Download limit is 2. Appending a query string must NOT drop the request to
+    // the looser general tier — the stricter download limit still applies.
+    for (let i = 0; i < 2; i++) {
+      const res = await app.inject({ method: 'GET', url: '/api/vault/test-id/download?x=' + i });
+      expect(res.statusCode).toBe(200);
+    }
+
+    const res = await app.inject({ method: 'GET', url: '/api/vault/test-id/download?x=3' });
+    expect(res.statusCode).toBe(429);
+  });
+
+  it('should not let a query string bypass the upload tier', async () => {
+    // Upload limit is 3. A trailing query string must not evade it.
+    for (let i = 0; i < 3; i++) {
+      const res = await app.inject({ method: 'POST', url: '/api/vault?x=' + i });
+      expect(res.statusCode).toBe(200);
+    }
+
+    const res = await app.inject({ method: 'POST', url: '/api/vault?x=4' });
+    expect(res.statusCode).toBe(429);
+  });
+
   it('should include retryAfter in 429 response body', async () => {
     // Exhaust general limit
     for (let i = 0; i < 5; i++) {

--- a/backend/src/__tests__/vaultManager.test.ts
+++ b/backend/src/__tests__/vaultManager.test.ts
@@ -238,6 +238,50 @@ describe('VaultManager — download counter atomicity', () => {
     ).rejects.toThrow(/not found/);
   });
 
+  it('caps concurrent open upload sessions per IP', async () => {
+    vi.resetModules();
+    vi.stubEnv('STORAGE_PATH', tempDir);
+    vi.stubEnv('MAX_FILE_SIZE', String(10 * 1024 * 1024));
+    vi.stubEnv('MAX_TTL', '604800');
+    vi.stubEnv('MAX_UPLOAD_SESSIONS_PER_IP', '2');
+    const mod = await import('../vault/manager.js');
+    const capped = new mod.VaultManager();
+    await capped.init();
+
+    const ip = '203.0.113.7';
+    capped.initChunkedUpload(100, 3600, 1, undefined, ip);
+    capped.initChunkedUpload(100, 3600, 1, undefined, ip);
+
+    // Third concurrent session from the same IP must be rejected
+    expect(() => capped.initChunkedUpload(100, 3600, 1, undefined, ip)).toThrow(/Too many concurrent uploads/);
+
+    // A different IP is unaffected
+    expect(() => capped.initChunkedUpload(100, 3600, 1, undefined, '198.51.100.9')).not.toThrow();
+
+    await capped.shutdown();
+  });
+
+  it('frees the per-IP session slot when an upload completes', async () => {
+    vi.resetModules();
+    vi.stubEnv('STORAGE_PATH', tempDir);
+    vi.stubEnv('MAX_FILE_SIZE', String(10 * 1024 * 1024));
+    vi.stubEnv('MAX_TTL', '604800');
+    vi.stubEnv('MAX_UPLOAD_SESSIONS_PER_IP', '1');
+    const mod = await import('../vault/manager.js');
+    const capped = new mod.VaultManager();
+    await capped.init();
+
+    const ip = '203.0.113.8';
+    const s1 = capped.initChunkedUpload(50, 3600, 1, undefined, ip);
+    await capped.appendChunk(s1.uploadId, 0, makeStream('x'.repeat(50)));
+    await capped.completeChunkedUpload(s1.uploadId);
+
+    // Slot must be released — a new session from the same IP now succeeds
+    expect(() => capped.initChunkedUpload(50, 3600, 1, undefined, ip)).not.toThrow();
+
+    await capped.shutdown();
+  });
+
   // ------------------------------------------------------------------
   // Orphan cleanup on startup
   // ------------------------------------------------------------------

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -29,6 +29,10 @@ const envSchema = {
   // How long an incomplete chunked upload session stays alive (seconds, default 60 min).
   // Must be long enough for the largest allowed file on the slowest expected link.
   UPLOAD_SESSION_TTL: Number(process.env.UPLOAD_SESSION_TTL || 3600),
+  // Max concurrent open chunked-upload sessions a single client IP may hold.
+  // Bounds the storage-quota reservation an attacker can tie up by opening
+  // sessions and never completing them. 0 = unlimited (not recommended).
+  MAX_UPLOAD_SESSIONS_PER_IP: Number(process.env.MAX_UPLOAD_SESSIONS_PER_IP || 10),
   // Per-chunk plaintext size for client-side AES-GCM streaming encryption.
   // Each chunk is encrypted independently with a unique IV and chunkIndex in AAD.
   // Default: min(5 MB, CHUNK_SIZE) — auto-clamped so smaller CHUNK_SIZE values don't crash.
@@ -91,6 +95,9 @@ export function validateConfig(): void {
   }
   if (!isFinite(config.UPLOAD_SESSION_TTL) || config.UPLOAD_SESSION_TTL <= 0) {
     throw new Error('UPLOAD_SESSION_TTL must be a positive number');
+  }
+  if (!isFinite(config.MAX_UPLOAD_SESSIONS_PER_IP) || config.MAX_UPLOAD_SESSIONS_PER_IP < 0) {
+    throw new Error('MAX_UPLOAD_SESSIONS_PER_IP must be a non-negative number');
   }
   if (!isFinite(config.MAX_TOTAL_STORAGE) || config.MAX_TOTAL_STORAGE < 0) {
     throw new Error('MAX_TOTAL_STORAGE must be a non-negative number');

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -75,7 +75,12 @@ export async function rateLimitPlugin(app: FastifyInstance): Promise<void> {
   const windowMs = config.RATE_LIMIT_WINDOW * 1000;
 
   app.addHook('onRequest', async (request: FastifyRequest, reply: FastifyReply) => {
-    if (!request.url.startsWith('/api/')) return;
+    // Match on the pathname only — never the raw URL. `request.url` includes the
+    // query string, so matching it directly would let a client append `?x=1` to a
+    // sensitive path and slip past the stricter upload/download tiers, falling back
+    // to the looser general limit.
+    const pathname = request.url.split('?', 1)[0];
+    if (!pathname.startsWith('/api/')) return;
 
     // `request.ip` is already resolved via Fastify's trustProxy chain.
     const ip = request.ip;
@@ -84,7 +89,7 @@ export async function rateLimitPlugin(app: FastifyInstance): Promise<void> {
     if (!checkLimit(apiBuckets, ip, config.RATE_LIMIT_API_MAX, windowMs, reply)) return;
 
     // Tier 2a — admin routes get a dedicated strict limit (brute-force protection)
-    if (request.url.startsWith('/api/admin')) {
+    if (pathname.startsWith('/api/admin')) {
       if (!checkLimit(adminBuckets, ip, config.RATE_LIMIT_ADMIN_MAX, windowMs, reply)) return;
     }
 
@@ -92,14 +97,14 @@ export async function rateLimitPlugin(app: FastifyInstance): Promise<void> {
     // Individual chunk requests (/chunk, /complete) are NOT counted here — a single large
     // file upload generates N+2 POST requests and would exhaust the limit mid-upload.
     const isNewUpload =
-      (request.url === '/api/vault' && request.method === 'POST') ||
-      (request.url === '/api/vault/upload/init' && request.method === 'POST');
+      (pathname === '/api/vault' && request.method === 'POST') ||
+      (pathname === '/api/vault/upload/init' && request.method === 'POST');
     if (isNewUpload) {
       if (!checkLimit(uploadBuckets, ip, config.RATE_LIMIT_MAX, windowMs, reply)) return;
     }
 
     // Tier 3 — download limit (prevents bulk enumeration / download exhaustion)
-    if (/^\/api\/vault\/[^/]+\/download$/.test(request.url) && request.method === 'GET') {
+    if (/^\/api\/vault\/[^/]+\/download$/.test(pathname) && request.method === 'GET') {
       checkLimit(downloadBuckets, ip, config.RATE_LIMIT_DOWNLOAD_MAX, windowMs, reply);
     }
   });

--- a/backend/src/routes/vault.ts
+++ b/backend/src/routes/vault.ts
@@ -129,7 +129,7 @@ export async function vaultRoutes(app: FastifyInstance): Promise<void> {
     }
 
     try {
-      const session = vaultManager.initChunkedUpload(totalSize, ttl, maxDownloads, chunkPlaintextSize);
+      const session = vaultManager.initChunkedUpload(totalSize, ttl, maxDownloads, chunkPlaintextSize, request.ip);
       const sessionToken = vaultManager.signUploadSession(session.uploadId);
       return reply.status(201).send({
         uploadId: session.uploadId,

--- a/backend/src/vault/manager.ts
+++ b/backend/src/vault/manager.ts
@@ -16,6 +16,13 @@ const uploadSessions = new Map<string, ChunkedUploadSession>();
  */
 let reservedBytes = 0;
 
+/**
+ * Count of open (uncompleted) chunked-upload sessions per client IP.
+ * Caps how much storage quota a single IP can tie up via reservations
+ * without ever completing an upload (reservation-exhaustion DoS).
+ */
+const ipSessionCounts = new Map<string, number>();
+
 /** HMAC secret generated at startup — used to sign upload session tokens. */
 const sessionSecret = randomBytes(32);
 
@@ -79,12 +86,25 @@ export class VaultManager {
     const expiredSessions = Array.from(uploadSessions.entries())
       .filter(([, session]) => session.expiresAt <= now)
       .map(([id, session]) => {
-        reservedBytes = Math.max(0, reservedBytes - session.totalSize);
+        this.releaseSessionAccounting(session);
         uploadSessions.delete(id);
         return storage.deleteChunkedUpload(id).catch(() => {});
       });
 
     await Promise.allSettled([...expiredVaults, ...expiredSessions]);
+  }
+
+  /**
+   * Release the quota reservation and per-IP session slot held by a session.
+   * Must be called whenever a session is discarded (completed, aborted, or expired).
+   */
+  private releaseSessionAccounting(session: ChunkedUploadSession): void {
+    reservedBytes = Math.max(0, reservedBytes - session.totalSize);
+    if (session.clientIp) {
+      const remaining = (ipSessionCounts.get(session.clientIp) ?? 0) - 1;
+      if (remaining <= 0) ipSessionCounts.delete(session.clientIp);
+      else ipSessionCounts.set(session.clientIp, remaining);
+    }
   }
 
   async createVault(
@@ -143,11 +163,25 @@ export class VaultManager {
 
   // ── Chunked upload ────────────────────────────────────────────────────────
 
-  initChunkedUpload(totalSize: number, ttl: number, maxDownloads: number, chunkPlaintextSize: number = config.CRYPTO_CHUNK_SIZE): ChunkedUploadSession {
+  initChunkedUpload(totalSize: number, ttl: number, maxDownloads: number, chunkPlaintextSize: number = config.CRYPTO_CHUNK_SIZE, clientIp?: string): ChunkedUploadSession {
     const plaintextMax = config.MAX_FILE_SIZE + MAX_METADATA_HEADER;
     const maxAllowed = plaintextMax + calcEncryptionOverhead(plaintextMax);
     if (totalSize <= 0 || totalSize > maxAllowed) {
       throw Object.assign(new Error('Invalid total size'), { statusCode: 400 });
+    }
+
+    // Cap concurrent open sessions per IP. Without this, a single client can open
+    // many sessions — each reserving quota via reservedBytes — and never complete
+    // them, tying up MAX_TOTAL_STORAGE and blocking legitimate uploads until the
+    // sessions expire (reservation-exhaustion DoS).
+    if (clientIp && config.MAX_UPLOAD_SESSIONS_PER_IP > 0) {
+      const open = ipSessionCounts.get(clientIp) ?? 0;
+      if (open >= config.MAX_UPLOAD_SESSIONS_PER_IP) {
+        throw Object.assign(
+          new Error('Too many concurrent uploads. Complete or cancel an upload before starting another.'),
+          { statusCode: 429 }
+        );
+      }
     }
 
     // Enforce global storage quota — include reservedBytes to prevent TOCTOU.
@@ -161,8 +195,9 @@ export class VaultManager {
       }
     }
 
-    // Reserve quota for the duration of the upload session
+    // Reserve quota and a per-IP session slot for the duration of the upload.
     reservedBytes += totalSize;
+    if (clientIp) ipSessionCounts.set(clientIp, (ipSessionCounts.get(clientIp) ?? 0) + 1);
 
     const uploadId = nanoid(24);
     const session: ChunkedUploadSession = {
@@ -174,6 +209,7 @@ export class VaultManager {
       maxDownloads: Math.min(Math.max(maxDownloads, 1), 1000),
       chunkPlaintextSize,
       expiresAt: Date.now() + config.UPLOAD_SESSION_TTL * 1000,
+      clientIp,
     };
     uploadSessions.set(uploadId, session);
     return session;
@@ -183,6 +219,7 @@ export class VaultManager {
     const session = uploadSessions.get(uploadId);
     if (!session || session.expiresAt <= Date.now()) {
       if (session) {
+        this.releaseSessionAccounting(session);
         uploadSessions.delete(uploadId);
         await storage.deleteChunkedUpload(uploadId).catch(() => {});
       }
@@ -223,7 +260,7 @@ export class VaultManager {
     const session = uploadSessions.get(uploadId);
     if (!session || session.expiresAt <= Date.now()) {
       if (session) {
-        reservedBytes = Math.max(0, reservedBytes - session.totalSize);
+        this.releaseSessionAccounting(session);
         uploadSessions.delete(uploadId);
         await storage.deleteChunkedUpload(uploadId).catch(() => {});
       }
@@ -231,7 +268,7 @@ export class VaultManager {
     }
 
     if (session.receivedBytes === 0) {
-      reservedBytes = Math.max(0, reservedBytes - session.totalSize);
+      this.releaseSessionAccounting(session);
       uploadSessions.delete(uploadId);
       await storage.deleteChunkedUpload(uploadId).catch(() => {});
       throw Object.assign(new Error('No chunks received'), { statusCode: 400 });
@@ -248,7 +285,7 @@ export class VaultManager {
     const now = Date.now();
 
     await storage.finalizeChunkedUpload(uploadId, vaultId);
-    reservedBytes = Math.max(0, reservedBytes - session.totalSize);
+    this.releaseSessionAccounting(session);
     uploadSessions.delete(uploadId);
 
     const meta: VaultMetadata = {
@@ -269,7 +306,7 @@ export class VaultManager {
   async abortChunkedUpload(uploadId: string): Promise<void> {
     const session = uploadSessions.get(uploadId);
     if (session) {
-      reservedBytes = Math.max(0, reservedBytes - session.totalSize);
+      this.releaseSessionAccounting(session);
     }
     uploadSessions.delete(uploadId);
     await storage.deleteChunkedUpload(uploadId).catch(() => {});

--- a/backend/src/vault/types.ts
+++ b/backend/src/vault/types.ts
@@ -38,4 +38,6 @@ export interface ChunkedUploadSession {
   chunkPlaintextSize: number;
   /** Absolute timestamp (ms) after which the session is garbage-collected. */
   expiresAt: number;
+  /** Client IP that opened the session — used to cap concurrent sessions per IP. */
+  clientIp?: string;
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -39,6 +39,7 @@ The README covers the variables you usually touch. This page is the complete ref
 | `CHUNK_SIZE` | `10485760` | Chunk size in bytes for the chunked upload protocol (default 10 MB) — each HTTP request stays below this limit, which lets uploads pass through Cloudflare's 100 MB per-request cap. Also used by the frontend as the threshold for switching to the chunked upload flow. Smaller chunks work better for homelab/Tailscale/VPS setups with limited bandwidth. |
 | `CRYPTO_CHUNK_SIZE` | `5242880` | Crypto chunk size in bytes (default 5 MB) — each plaintext chunk is encrypted independently with AES-256-GCM using a unique IV and chunk index as AAD. Smaller values reduce peak memory; larger values reduce per-chunk overhead (28 bytes per chunk). |
 | `UPLOAD_SESSION_TTL` | `3600` | How long an incomplete chunked upload session stays alive in seconds (default 60 min) — increased from 30 min to support 1 GB uploads on slow links (5 Mbps ≈ 26 min) |
+| `MAX_UPLOAD_SESSIONS_PER_IP` | `10` | Max concurrent open chunked-upload sessions a single client IP may hold (`0` = unlimited, not recommended). Each open session reserves its declared size against `MAX_TOTAL_STORAGE`; without this cap a single IP could open many sessions and never complete them, tying up the storage quota and blocking legitimate uploads until the sessions expire. |
 
 ### Rate limiting
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2253,9 +2253,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/src/__tests__/crypto.test.ts
+++ b/frontend/src/__tests__/crypto.test.ts
@@ -114,10 +114,10 @@ describe('crypto/encrypt', () => {
       const key = await generateKey();
       const plaintext = new TextEncoder().encode('Hello, streaming encryption! 🔐');
 
-      const encrypted = await encryptChunk(plaintext, key, 0);
+      const encrypted = await encryptChunk(plaintext, key, 0, true);
       expect(encrypted.length).toBe(plaintext.length + PER_CHUNK_OVERHEAD);
 
-      const decrypted = await decryptChunk(encrypted, key, 0);
+      const decrypted = await decryptChunk(encrypted, key, 0, true);
       expect(decrypted).toEqual(plaintext);
     });
 
@@ -125,8 +125,8 @@ describe('crypto/encrypt', () => {
       const key = await generateKey();
       const plaintext = new Uint8Array([1, 2, 3]);
 
-      const enc1 = await encryptChunk(plaintext, key, 0);
-      const enc2 = await encryptChunk(plaintext, key, 1);
+      const enc1 = await encryptChunk(plaintext, key, 0, false);
+      const enc2 = await encryptChunk(plaintext, key, 1, true);
 
       const iv1 = enc1.slice(0, IV_LENGTH);
       const iv2 = enc2.slice(0, IV_LENGTH);
@@ -138,36 +138,50 @@ describe('crypto/encrypt', () => {
       const key2 = await generateKey();
       const plaintext = new Uint8Array([1, 2, 3]);
 
-      const encrypted = await encryptChunk(plaintext, key1, 0);
+      const encrypted = await encryptChunk(plaintext, key1, 0, true);
 
-      await expect(decryptChunk(encrypted, key2, 0)).rejects.toThrow();
+      await expect(decryptChunk(encrypted, key2, 0, true)).rejects.toThrow();
     });
 
     it('should fail decryption with wrong chunkIndex (reorder protection)', async () => {
       const key = await generateKey();
       const plaintext = new Uint8Array([1, 2, 3]);
 
-      const encrypted = await encryptChunk(plaintext, key, 0);
+      const encrypted = await encryptChunk(plaintext, key, 0, true);
 
       // Decrypt with chunkIndex=1 instead of 0 — AAD mismatch → GCM auth failure
-      await expect(decryptChunk(encrypted, key, 1)).rejects.toThrow();
+      await expect(decryptChunk(encrypted, key, 1, true)).rejects.toThrow();
+    });
+
+    it('should fail decryption with wrong isLast flag (truncation protection)', async () => {
+      const key = await generateKey();
+      const plaintext = new Uint8Array([1, 2, 3]);
+
+      // Encrypted as a NON-final chunk; decrypting it as the final chunk (as a
+      // truncating server would force) must fail authentication.
+      const middle = await encryptChunk(plaintext, key, 0, false);
+      await expect(decryptChunk(middle, key, 0, true)).rejects.toThrow();
+
+      // And the inverse: a final chunk decrypted as non-final also fails.
+      const last = await encryptChunk(plaintext, key, 0, true);
+      await expect(decryptChunk(last, key, 0, false)).rejects.toThrow();
     });
 
     it('should reject too-short data', async () => {
       const key = await generateKey();
       const tooShort = new Uint8Array(20); // Less than IV + tag
 
-      await expect(decryptChunk(tooShort, key, 0)).rejects.toThrow('too short');
+      await expect(decryptChunk(tooShort, key, 0, true)).rejects.toThrow('too short');
     });
 
     it('should handle empty chunk', async () => {
       const key = await generateKey();
       const empty = new Uint8Array(0);
 
-      const encrypted = await encryptChunk(empty, key, 0);
+      const encrypted = await encryptChunk(empty, key, 0, true);
       expect(encrypted.length).toBe(PER_CHUNK_OVERHEAD); // just IV + tag
 
-      const decrypted = await decryptChunk(encrypted, key, 0);
+      const decrypted = await decryptChunk(encrypted, key, 0, true);
       expect(decrypted.length).toBe(0);
     });
 
@@ -175,8 +189,8 @@ describe('crypto/encrypt', () => {
       const key = await generateKey();
       const single = new Uint8Array([42]);
 
-      const encrypted = await encryptChunk(single, key, 0);
-      const decrypted = await decryptChunk(encrypted, key, 0);
+      const encrypted = await encryptChunk(single, key, 0, true);
+      const decrypted = await decryptChunk(encrypted, key, 0, true);
       expect(decrypted).toEqual(single);
     });
 
@@ -187,8 +201,8 @@ describe('crypto/encrypt', () => {
         crypto.getRandomValues(data.subarray(i, Math.min(i + 65536, data.length)));
       }
 
-      const encrypted = await encryptChunk(data, key, 0);
-      const decrypted = await decryptChunk(encrypted, key, 0);
+      const encrypted = await encryptChunk(data, key, 0, true);
+      const decrypted = await decryptChunk(encrypted, key, 0, true);
       expect(decrypted).toEqual(data);
     });
   });
@@ -214,7 +228,7 @@ describe('crypto/encrypt', () => {
       while (offset < fullPlaintext.length) {
         const end = Math.min(offset + chunkSize, fullPlaintext.length);
         const chunk = fullPlaintext.slice(offset, end);
-        encryptedChunks.push(await encryptChunk(chunk, key, chunkIndex));
+        encryptedChunks.push(await encryptChunk(chunk, key, chunkIndex, end === fullPlaintext.length));
         offset = end;
         chunkIndex++;
       }
@@ -222,7 +236,7 @@ describe('crypto/encrypt', () => {
       // Decrypt all chunks
       const decryptedParts: Uint8Array[] = [];
       for (let i = 0; i < encryptedChunks.length; i++) {
-        decryptedParts.push(await decryptChunk(encryptedChunks[i], key, i));
+        decryptedParts.push(await decryptChunk(encryptedChunks[i], key, i, i === encryptedChunks.length - 1));
       }
 
       // Reassemble
@@ -245,16 +259,16 @@ describe('crypto/encrypt', () => {
 
     it('should detect chunk reordering in multi-chunk flow', async () => {
       const key = await generateKey();
-      const chunk0 = await encryptChunk(new Uint8Array([1, 2, 3]), key, 0);
-      const chunk1 = await encryptChunk(new Uint8Array([4, 5, 6]), key, 1);
+      const chunk0 = await encryptChunk(new Uint8Array([1, 2, 3]), key, 0, false);
+      const chunk1 = await encryptChunk(new Uint8Array([4, 5, 6]), key, 1, true);
 
       // Swapped: try to decrypt chunk1 as index 0 and vice versa
-      await expect(decryptChunk(chunk1, key, 0)).rejects.toThrow();
-      await expect(decryptChunk(chunk0, key, 1)).rejects.toThrow();
+      await expect(decryptChunk(chunk1, key, 0, false)).rejects.toThrow();
+      await expect(decryptChunk(chunk0, key, 1, true)).rejects.toThrow();
 
       // Correct order works
-      await expect(decryptChunk(chunk0, key, 0)).resolves.toEqual(new Uint8Array([1, 2, 3]));
-      await expect(decryptChunk(chunk1, key, 1)).resolves.toEqual(new Uint8Array([4, 5, 6]));
+      await expect(decryptChunk(chunk0, key, 0, false)).resolves.toEqual(new Uint8Array([1, 2, 3]));
+      await expect(decryptChunk(chunk1, key, 1, true)).resolves.toEqual(new Uint8Array([4, 5, 6]));
     });
   });
 

--- a/frontend/src/api/vault.ts
+++ b/frontend/src/api/vault.ts
@@ -87,7 +87,7 @@ export async function uploadVault(
     const start = i * chunkPlaintextSize;
     const end = Math.min(start + chunkPlaintextSize, totalPlaintext);
     const plaintext = await readVirtualRange(header, file, start, end);
-    encryptedParts.push(await encryptChunk(plaintext as Uint8Array<ArrayBuffer>, key, i));
+    encryptedParts.push(await encryptChunk(plaintext as Uint8Array<ArrayBuffer>, key, i, i === numCryptoChunks - 1));
     onProgress?.(((i + 1) / numCryptoChunks) * 0.3);
   }
 
@@ -226,7 +226,7 @@ export async function uploadVaultChunked(
         const start = i * chunkPlaintextSize;
         const end = Math.min(start + chunkPlaintextSize, totalPlaintext);
         const plaintext = await readVirtualRange(header, file, start, end);
-        parts.push(await encryptChunk(plaintext as Uint8Array<ArrayBuffer>, key, i));
+        parts.push(await encryptChunk(plaintext as Uint8Array<ArrayBuffer>, key, i, i === numCryptoChunks - 1));
       }
 
       const form = new FormData();

--- a/frontend/src/api/vault.ts
+++ b/frontend/src/api/vault.ts
@@ -80,14 +80,17 @@ export async function uploadVault(
   const totalPlaintext = header.length + file.size;
   const numCryptoChunks = Math.max(1, Math.ceil(totalPlaintext / chunkPlaintextSize));
 
-  // Encrypt all crypto chunks
+  // Encrypt all crypto chunks. Each ciphertext chunk is wrapped in a Blob right
+  // away so the JS heap holds one chunk at a time rather than the whole encrypted
+  // file; the browser manages the accumulated Blob parts.
   const encryptedParts: BlobPart[] = [];
   for (let i = 0; i < numCryptoChunks; i++) {
     signal?.throwIfAborted();
     const start = i * chunkPlaintextSize;
     const end = Math.min(start + chunkPlaintextSize, totalPlaintext);
     const plaintext = await readVirtualRange(header, file, start, end);
-    encryptedParts.push(await encryptChunk(plaintext as Uint8Array<ArrayBuffer>, key, i, i === numCryptoChunks - 1));
+    const encrypted = await encryptChunk(plaintext as Uint8Array<ArrayBuffer>, key, i, i === numCryptoChunks - 1);
+    encryptedParts.push(new Blob([encrypted]));
     onProgress?.(((i + 1) / numCryptoChunks) * 0.3);
   }
 

--- a/frontend/src/crypto/encrypt.ts
+++ b/frontend/src/crypto/encrypt.ts
@@ -13,8 +13,11 @@
  *   Chunks are concatenated sequentially on disk:
  *     [chunk_0][chunk_1]...[chunk_N]
  *
- *   Additional Authenticated Data (AAD) = chunk index (uint32 BE)
- *   This prevents chunk reordering attacks.
+ *   Additional Authenticated Data (AAD) = chunk index (uint32 BE) || isLast (uint8)
+ *   The chunk index prevents reordering. The isLast flag marks the final chunk,
+ *   so a server that drops trailing chunks (truncation) or appends extra ones
+ *   (extension) leaves a chunk whose stored isLast no longer matches the value
+ *   the client supplies during decryption — GCM authentication then fails.
  *
  * Plaintext layout (before per-chunk AES-GCM encryption):
  *   Chunk 0: [uint16 BE: nameLen][filename UTF-8][uint16 BE: mimeLen][MIME UTF-8][file bytes...]
@@ -114,21 +117,35 @@ export function parseMetadataHeader(plaintext: Uint8Array): {
 }
 
 /**
+ * Build the per-chunk AAD: [uint32 BE chunkIndex][uint8 isLast].
+ * Binds both ordering and the total chunk count (via the final-chunk marker)
+ * into every chunk's authentication tag.
+ */
+function buildChunkAad(chunkIndex: number, isLast: boolean): ArrayBuffer {
+  const aad = new ArrayBuffer(5);
+  const view = new DataView(aad);
+  view.setUint32(0, chunkIndex, false);
+  view.setUint8(4, isLast ? 1 : 0);
+  return aad;
+}
+
+/**
  * Encrypt a single plaintext chunk with AES-256-GCM.
  *
  * @param plaintext  Raw chunk bytes (≤ cryptoChunkSize)
  * @param key        AES-256-GCM CryptoKey
- * @param chunkIndex 0-based index, used as AAD to prevent reordering
+ * @param chunkIndex 0-based index, bound into AAD to prevent reordering
+ * @param isLast     Whether this is the final chunk, bound into AAD to prevent truncation
  * @returns [IV (12 bytes) || ciphertext || GCM tag (16 bytes)]
  */
 export async function encryptChunk(
   plaintext: BufferSource,
   key: CryptoKey,
-  chunkIndex: number
+  chunkIndex: number,
+  isLast: boolean
 ): Promise<Uint8Array<ArrayBuffer>> {
   const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
-  const aad = new ArrayBuffer(4);
-  new DataView(aad).setUint32(0, chunkIndex, false);
+  const aad = buildChunkAad(chunkIndex, isLast);
 
   const ciphertext = await crypto.subtle.encrypt(
     { name: ALGORITHM, iv, additionalData: aad },
@@ -148,12 +165,14 @@ export async function encryptChunk(
  * @param chunk      [IV (12 bytes) || ciphertext || GCM tag (16 bytes)]
  * @param key        AES-256-GCM CryptoKey
  * @param chunkIndex Must match the index used during encryption (AAD)
+ * @param isLast     Must match the final-chunk flag used during encryption (AAD)
  * @returns Decrypted plaintext bytes
  */
 export async function decryptChunk(
   chunk: Uint8Array,
   key: CryptoKey,
-  chunkIndex: number
+  chunkIndex: number,
+  isLast: boolean
 ): Promise<Uint8Array<ArrayBuffer>> {
   if (chunk.length < IV_LENGTH + GCM_TAG_LENGTH) {
     throw new Error('Invalid encrypted chunk: too short');
@@ -161,8 +180,7 @@ export async function decryptChunk(
 
   const iv = chunk.slice(0, IV_LENGTH);
   const ciphertext = chunk.slice(IV_LENGTH);
-  const aad = new ArrayBuffer(4);
-  new DataView(aad).setUint32(0, chunkIndex, false);
+  const aad = buildChunkAad(chunkIndex, isLast);
 
   const plaintext = await crypto.subtle.decrypt(
     { name: ALGORITHM, iv, additionalData: aad },

--- a/frontend/src/pages/Vault.tsx
+++ b/frontend/src/pages/Vault.tsx
@@ -71,7 +71,7 @@ export default function Vault() {
         const start = i * chunkCT;
         const end = Math.min(start + chunkCT, encryptedBlob.size);
         const chunkBytes = new Uint8Array(await encryptedBlob.slice(start, end).arrayBuffer());
-        decryptedParts.push(await decryptChunk(chunkBytes, key, i));
+        decryptedParts.push(await decryptChunk(chunkBytes, key, i, i === numChunks - 1));
         setProgress(0.4 + ((i + 1) / numChunks) * 0.55);
       }
 

--- a/frontend/src/pages/Vault.tsx
+++ b/frontend/src/pages/Vault.tsx
@@ -61,29 +61,34 @@ export default function Vault() {
       setStage('decrypting');
       const key = await importKey(keyFragment);
 
-      // Streaming per-chunk decryption
+      // Streaming per-chunk decryption. Each decrypted chunk is wrapped in a Blob
+      // immediately and its plaintext view dropped, so the JS heap holds at most one
+      // chunk at a time instead of the whole file — the accumulating Blob parts are
+      // managed by the browser (and may be spilled to disk).
       const chunkPT = info.chunkPlaintextSize;
       const chunkCT = chunkPT + PER_CHUNK_OVERHEAD;
       const numChunks = Math.ceil(encryptedBlob.size / chunkCT);
-      const decryptedParts: Uint8Array[] = [];
+      const contentParts: BlobPart[] = [];
+      let filename = 'file';
+      let mimeType = 'application/octet-stream';
 
       for (let i = 0; i < numChunks; i++) {
         const start = i * chunkCT;
         const end = Math.min(start + chunkCT, encryptedBlob.size);
         const chunkBytes = new Uint8Array(await encryptedBlob.slice(start, end).arrayBuffer());
-        decryptedParts.push(await decryptChunk(chunkBytes, key, i, i === numChunks - 1));
+        const plaintext = await decryptChunk(chunkBytes, key, i, i === numChunks - 1);
+
+        if (i === 0) {
+          // The metadata header (filename + MIME) prefixes the first chunk's plaintext.
+          const meta = parseMetadataHeader(plaintext);
+          filename = meta.filename;
+          mimeType = meta.mimeType;
+          setDecryptedFilename(filename);
+          contentParts.push(new Blob([plaintext.slice(meta.contentOffset)]));
+        } else {
+          contentParts.push(new Blob([plaintext]));
+        }
         setProgress(0.4 + ((i + 1) / numChunks) * 0.55);
-      }
-
-      // Parse metadata header from first decrypted chunk
-      const firstChunk = decryptedParts[0];
-      const { filename, mimeType, contentOffset } = parseMetadataHeader(firstChunk);
-      setDecryptedFilename(filename);
-
-      // Assemble file: first chunk minus header, then remaining chunks
-      const contentParts: BlobPart[] = [firstChunk.slice(contentOffset) as BlobPart];
-      for (let i = 1; i < decryptedParts.length; i++) {
-        contentParts.push(decryptedParts[i] as BlobPart);
       }
 
       const decryptedFile = new File(contentParts, filename, { type: mimeType });


### PR DESCRIPTION
## Description

Fixes from a security and optimization audit of the codebase. Five independent changes, one topic per commit:

1. **Rate-limit query-string bypass (`fix`)** — the upload and download tiers matched on `request.url`, which includes the query string. Appending `?x=1` to `/api/vault/:id/download` (or `POST /api/vault`) fell through to only the looser general limit. Matching now happens on the parsed pathname.
2. **Reservation-exhaustion DoS (`fix`)** — `initChunkedUpload` reserves the client-declared `totalSize` against `MAX_TOTAL_STORAGE` for up to `UPLOAD_SESSION_TTL` (1 h) even if no bytes are ever uploaded. A single IP could open many sessions and lock out all legitimate uploads. Added a per-IP concurrent-session cap (`MAX_UPLOAD_SESSIONS_PER_IP`, default 10) and routed every session-teardown path through one accounting helper (which also fixes a pre-existing reservation leak on the expired-append branch).
3. **Ciphertext truncation detection (`fix`)** — the per-chunk AEAD bound only the chunk index into the AAD, so a malicious/compromised server could drop trailing chunks and the client would decrypt the truncated prefix with no integrity error. A final-chunk flag is now bound into the AAD; dropping or appending chunks makes GCM authentication fail. **This changes the on-the-wire crypto format** — see Breaking change below.
4. **Browser heap during transfer (`perf`)** — single-request upload and download buffered the entire file (plus copies) in the JS heap, ~2–3× file size at peak, enough to crash low-RAM tabs at the 100 MB default. Each crypto chunk is now wrapped in a `Blob` as it's produced, so the JS heap holds at most one chunk while the browser manages the accumulated (potentially disk-backed) Blob parts.
5. **`brace-expansion` advisory (`chore`)** — patched the one moderate dev/build-only advisory (GHSA-jxxr-4gwj-5jf2) reported by `npm audit` in the frontend workspace. Lockfile-only; no declared-version changes.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

**Breaking change:** commit 3 alters the AEAD AAD, so vault links created before this change will fail to decrypt after deploy. Vaults are ephemeral (max TTL 7 days), so impact is bounded to links in flight at deploy time.

## Related Issue
N/A — findings from a local audit.

## How Has This Been Tested?
- [x] Unit tests — added coverage for the rate-limit bypass (query-string tiers), the per-IP session cap and slot release, and truncation detection (wrong `isLast` fails auth). Backend 129 tests + frontend 118 tests pass.
- [ ] Manual testing — the streaming Blob change (commit 4) preserves the existing auto-download UX and needs no API/compat change, but the large-file save path warrants a manual browser pass before release.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md (if applicable)

## ⚠️ Additional Security Checklist
- [x] No plaintext file content is stored or logged server-side
- [x] No encryption key leaves the client
- [x] Vault ID input is validated before any filesystem operation
- [x] No new unvalidated environment variable is introduced (`MAX_UPLOAD_SESSIONS_PER_IP` is validated in `validateConfig`)
- [x] `npm audit` shows no new high/critical findings (0 vulnerabilities in both workspaces after this PR)
- [x] All tests pass (backend + frontend)
- [x] ESLint passes with zero warnings (backend + frontend)
- [x] TypeScript compiles with zero errors (backend + frontend)

## Additional Information
Findings deliberately left out of scope (minor, not worth their own change): rate-limit bucket maps only prune every 5 min, `getStats()` is O(n) per upload, and HSTS `preload` is sent on plain-HTTP/dev responses.
