### PR TITLE
fix(docker): drop npm from the production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,23 +25,25 @@ FROM node:24-alpine AS production
 ARG CACHE_BUST_APK=""
 RUN apk upgrade --no-cache
 
-# Update npm to patch CVEs in npm's bundled dependencies:
-#   - minimatch + tar  (CVE-2026-27903, CVE-2026-27904, CVE-2026-29786, CVE-2026-31802)
-#   - undici WebSocket DoS (CVE-2026-12151) — 11.17.0+ bundles undici@6.26.0 (patched; 11.13.0 shipped 6.25.0)
-#   - tar gzip-bomb + malformed-header DoS (CVE-2026-59873, CVE-2026-59874) —
-#     11.17.0 bundled tar@7.5.16; 11.18.0 is the first release to bundle tar@7.5.19.
-RUN npm install -g npm@11.18.0
-
 # Security: non-root user
 RUN addgroup -g 1001 -S archivum && \
     adduser -u 1001 -S archivum -G archivum
 
 WORKDIR /app
 
-# Install production dependencies only
+# Install production dependencies only.
+#
+# npm is build-time tooling: the runtime entrypoint is plain `node`, so npm and
+# npx are deleted once the install finishes. This drops npm's own bundled
+# dependency tree (~18 MB) out of the shipped image, which is the only place
+# CVE-2026-14257 (brace-expansion <= 5.0.7) appears — no npm release up to
+# 12.0.2 bundles the 5.0.8 fix, so upgrading npm cannot clear it. Not shipping
+# a package manager in a production container is the right default anyway.
 WORKDIR /app/backend
 COPY backend/package.json backend/package-lock.json* backend/.npmrc* ./
-RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
+RUN npm ci --omit=dev --ignore-scripts \
+ && npm cache clean --force \
+ && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx /root/.npm
 WORKDIR /app
 
 # Copy built backend


### PR DESCRIPTION
## Problem

The `Trivy Docker image scan` job is the last red check on `dev`. It reports one HIGH:

| Vulnerability | Package | Installed | Fixed |
|---|---|---|---|
| CVE-2026-14257 | brace-expansion | 5.0.7 | 5.0.8 |

The vulnerable copy is **not an application dependency**. It sits inside npm's own bundled tree:

```
usr/local/lib/node_modules/npm/node_modules/brace-expansion/package.json
```

Both workspaces are already on `brace-expansion@5.0.8` (backend via #109, frontend via e7e634f), and `npm audit` passes cleanly. Only the image scan still fails.

## Why not just bump npm

Every npm release through the current latest bundles the vulnerable version — checked by installing each and reading the bundled manifest:

| npm | bundled brace-expansion |
|---|---|
| 11.18.0 (current pin) | 5.0.7 |
| 11.19.0 | 5.0.7 |
| 12.0.0 / 12.0.1 / 12.0.2 | 5.0.7 |

So there is no npm version to upgrade to, and suppressing a HIGH that has an upstream fix would be the wrong call.

## Fix

npm is build-time tooling. The runtime entrypoint is `node backend/dist/index.js`, and the base `docker-entrypoint.sh` only needs `node` on PATH — nothing in `backend/dist` references npm. Deleting `npm` and `npx` after `npm ci` removes the finding at its source, and takes npm's entire bundled dependency tree out of the shipped image so future npm-internal advisories stop surfacing as image findings at all.

This also drops `npm install -g npm@11.18.0`, whose only stated purpose was patching CVEs in that same bundled tree. Build-time extraction falls back to the base image's npm 11.16.0 — consistent with the `backend-build` and `frontend-build` stages, which never upgraded npm either, and registry tarballs are integrity-pinned by the lockfile.

## Result

- Trivy HIGH/CRITICAL in image: **1 → 0** (scanner exits 0)
- Image size: **334 MB → 270 MB**
- A package manager is no longer present in a production container

## Verification

Built and ran the image, not just scanned it:

- `/api/health` → `200`, container reports `health=healthy`
- 64 KiB upload → `GET /api/vault/:id/download` → **byte-identical** SHA-256
- Vault metadata endpoint correct; unknown vault → `404`
- SPA root and deep routes → `200`
- Six path-traversal probes against `@fastify/static` (encoded, backslash, mixed separator, `//`, `....//`) → `403` or SPA fallback, **no file leak**
- `command -v npm` → absent; `node -v` → v24.18.0

## Note

`corepack` and `yarn` are still present in the base image and are currently clean. They are the same class of unused build-time tooling and could be removed later if they ever attract advisories; left alone here to keep this change scoped.