### PR TITLE
chore(docker): strip corepack and yarn from the production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,19 +31,29 @@ RUN addgroup -g 1001 -S archivum && \
 
 WORKDIR /app
 
-# Install production dependencies only.
+# Install production dependencies only, then strip every package manager.
 #
-# npm is build-time tooling: the runtime entrypoint is plain `node`, so npm and
-# npx are deleted once the install finishes. This drops npm's own bundled
-# dependency tree (~18 MB) out of the shipped image, which is the only place
-# CVE-2026-14257 (brace-expansion <= 5.0.7) appears — no npm release up to
-# 12.0.2 bundles the 5.0.8 fix, so upgrading npm cannot clear it. Not shipping
-# a package manager in a production container is the right default anyway.
+# The runtime entrypoint is plain `node`, and the base docker-entrypoint.sh
+# only needs node on PATH — so npm, corepack and yarn are all build-time
+# tooling that has no business in the shipped image. Each one carries its own
+# vendored dependency tree, and those trees, not our dependencies, have been
+# the recurring source of image-scan findings: CVE-2026-14257
+# (brace-expansion <= 5.0.7) lives in npm's bundle and cannot be fixed by
+# upgrading, because every npm release through 12.0.2 still ships 5.0.7.
+# Deleting them removes that whole class of finding at the source.
+#
+# corepack and yarn are clean today; they are removed for the same reason, so
+# the next advisory in either never reaches a running container.
 WORKDIR /app/backend
 COPY backend/package.json backend/package-lock.json* backend/.npmrc* ./
 RUN npm ci --omit=dev --ignore-scripts \
  && npm cache clean --force \
- && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx /root/.npm
+ && rm -rf /usr/local/lib/node_modules/npm \
+           /usr/local/lib/node_modules/corepack \
+           /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+           /usr/local/bin/yarn /usr/local/bin/yarnpkg \
+           /opt/yarn-v* \
+           /root/.npm
 WORKDIR /app
 
 # Copy built backend


### PR DESCRIPTION
Follow-up to #112, which removed npm from the runtime image after npm's own vendored dependency tree — not our dependencies — turned out to be the source of the recurring `Trivy Docker image scan` findings.

`corepack` and `yarn` are the same class of leftover build-time tooling from the `node:24-alpine` base. Each ships its own vendored tree, and neither is reachable from the entrypoint: the container runs `node backend/dist/index.js`, and the base `docker-entrypoint.sh` only needs `node` on PATH.

Both are **clean today**. This is pre-emptive: removing them means the next advisory in either one never reaches a running container.

## Effect

| | before | after |
|---|---|---|
| `npm` / `npx` | absent (#112) | absent |
| `corepack` | present | **absent** |
| `yarn` / `yarnpkg` | present | **absent** |
| `/opt/yarn-v*` | present | **absent** |
| Trivy package-manager targets | 3 | **0** |
| `node` | v24.18.0 | v24.18.0 |

## On image size — correcting the record

This does **not** shrink the image, and I want to be precise since #112's description implied otherwise. `yarn` and `corepack` live in the base image layers, so `rm -rf` in a later layer only writes whiteouts — the bytes stay in the underlying layers.

Measured exactly:

```
dev baseline : 62,199,500 bytes
this branch  : 62,197,652 bytes   (-1,848 bytes)
```

The 334 MB → 270 MB drop in #112 came from deleting the `RUN npm install -g npm@11.18.0` line — a layer created *inside* this Dockerfile — not from the `rm -rf`. The gain here is attack surface and scanner hygiene, not size.

## Verification

Built and ran the image:

- `npm`, `npx`, `yarn`, `yarnpkg`, `corepack` → all report `ABSENT`; `/opt/yarn-*` gone
- `node -v` → `v24.18.0`, `/usr/local/bin/node` intact
- `/api/health` → `200`, container reports `health=healthy`
- 32 KiB upload → download → **byte-identical** SHA-256
- Trivy HIGH/CRITICAL: **0**; JSON output indexes 2 targets, none matching yarn/corepack/npm